### PR TITLE
Fix dylib mapping for OS X

### DIFF
--- a/MonoGame.Framework.dll.config
+++ b/MonoGame.Framework.dll.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<dllmap dll="SDL2.dll" os="osx" target="libSDL2.dylib"/>
-	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.dylib" />
+	<dllmap dll="SDL2.dll" os="osx" target="libSDL2-2.0.0.dylib"/>
+	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib" />
 	<dllmap dll="SDL2.dll" os="linux" cpu="x86" target="./x86/libSDL2-2.0.so.0"/>
 	<dllmap dll="soft_oal.dll" os="linux" cpu="x86" target="./x86/libopenal.so.1" />
 	<dllmap dll="SDL2.dll" os="linux" cpu="x86-64" target="./x64/libSDL2-2.0.so.0"/>


### PR DESCRIPTION
This is a small fix to the Mono dll mapping so that DesktopGL debugging works on OS X with the new SDL2 dependencies.

cc @KonajuGames 