### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
On mac the creation of .DS_Store files by the OS
causes the submodule to ALWAYS show as modified.
We need to ignore these files.